### PR TITLE
improved mainly for certificate access, fixed some bugs

### DIFF
--- a/src/Public/Connect-ZabbixServer.ps1
+++ b/src/Public/Connect-ZabbixServer.ps1
@@ -52,7 +52,7 @@ function Connect-ZabbixServer {
     )
     [System.Net.ServicePointManager]::SecurityProtocol = @("Tls12","Tls11")
 
-    if ($env:ZabbixUri) {
+    if ($env:ZabbixAuth) {
         Write-Warning -Message "$($MyInvocation.MyCommand.Name): Zabbix session information already exists. Disconnect any previous session before starting a new session."
         break
     }

--- a/src/Public/Connect-ZabbixServer.ps1
+++ b/src/Public/Connect-ZabbixServer.ps1
@@ -46,7 +46,9 @@ function Connect-ZabbixServer {
         [Parameter(Mandatory=$True)]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential
+        $Credential,
+
+        $Certificate = $Global:Certificate
     )
     [System.Net.ServicePointManager]::SecurityProtocol = @("Tls12","Tls11")
 
@@ -73,7 +75,7 @@ function Connect-ZabbixServer {
 
     try {
         Write-Verbose -Message "$($MyInvocation.MyCommand.Name): Submitting login request to $Uri"
-        $JsonResponse = Invoke-RestMethod -Uri $Uri -Method Put -Body $JsonRequest -ContentType 'application/json' -ErrorAction Stop
+        $JsonResponse = Invoke-RestMethod -Uri $Uri -Method Put -Body $JsonRequest -ContentType 'application/json' -Certificate $Certificate -ErrorAction Stop
     }
     catch {
         Write-Error "StatusCode: $($_.Exception.Response.StatusCode.value__)"

--- a/src/Public/Connect-ZabbixServer.ps1
+++ b/src/Public/Connect-ZabbixServer.ps1
@@ -48,6 +48,7 @@ function Connect-ZabbixServer {
         [System.Management.Automation.Credential()]
         $Credential
     )
+    [System.Net.ServicePointManager]::SecurityProtocol = @("Tls12","Tls11")
 
     if ($env:ZabbixUri) {
         Write-Warning -Message "$($MyInvocation.MyCommand.Name): Zabbix session information already exists. Disconnect any previous session before starting a new session."

--- a/src/Public/Disconnect-ZabbixServer.ps1
+++ b/src/Public/Disconnect-ZabbixServer.ps1
@@ -33,8 +33,8 @@ function Disconnect-ZabbixServer {
 
     try {
         $JsonResponse = Invoke-RestMethod -Uri $env:ZabbixUri -Method Put -Body $JsonRequest -ContentType 'application/json' -ErrorAction Stop
-        Remove-Item -Name env:ZabbixAuth -ErrorAction SilentlyContinue
-        Remove-Item -Name env:ZabbixUri -ErrorAction SilentlyContinue
+        Remove-Item -Path env:ZabbixAuth -ErrorAction SilentlyContinue
+        Remove-Item -Path env:ZabbixUri -ErrorAction SilentlyContinue
         Write-Verbose -Message "$JsonResponse"
     }
     catch {

--- a/src/Public/Disconnect-ZabbixServer.ps1
+++ b/src/Public/Disconnect-ZabbixServer.ps1
@@ -36,6 +36,12 @@ function Disconnect-ZabbixServer {
         Remove-Item -Path env:ZabbixAuth -ErrorAction SilentlyContinue
         Remove-Item -Path env:ZabbixUri -ErrorAction SilentlyContinue
         Write-Verbose -Message "$JsonResponse"
+        if ($JsonResponse.result = $true) {
+            Write-Verbose -Message 'logout succesfull'
+            }
+            else {
+                Write-Warning -Message 'logout not succesfull'
+                }
     }
     catch {
         Write-Error "StatusCode: $($_.Exception.Response.StatusCode.value__)"

--- a/src/Public/Disconnect-ZabbixServer.ps1
+++ b/src/Public/Disconnect-ZabbixServer.ps1
@@ -20,7 +20,7 @@ function Disconnect-ZabbixServer {
 
     Param( $Certificate = $Global:Certificate )
 
-    if (!($env:ZabbixUri)) {
+    if (!($env:ZabbixAuth)) {
         Write-Warning -Message "$($MyInvocation.MyCommand.Name): No active sessions found."
         break
     }

--- a/src/Public/Disconnect-ZabbixServer.ps1
+++ b/src/Public/Disconnect-ZabbixServer.ps1
@@ -18,8 +18,7 @@ function Disconnect-ZabbixServer {
     #>
     [CmdletBinding()]
 
-    Param(
-    )
+    Param( $Certificate = $Global:Certificate )
 
     if (!($env:ZabbixUri)) {
         Write-Warning -Message "$($MyInvocation.MyCommand.Name): No active sessions found."
@@ -32,7 +31,7 @@ function Disconnect-ZabbixServer {
     Write-Verbose -Message "$($MyInvocation.MyCommand.Name): Sending JSON request object`n$($JsonRequest -Replace $env:ZabbixAuth, 'XXXXXX')"
 
     try {
-        $JsonResponse = Invoke-RestMethod -Uri $env:ZabbixUri -Method Put -Body $JsonRequest -ContentType 'application/json' -ErrorAction Stop
+        $JsonResponse = Invoke-RestMethod -Uri $env:ZabbixUri -Method Put -Body $JsonRequest -ContentType 'application/json' -Certificate $Certificate -ErrorAction Stop
         Remove-Item -Path env:ZabbixAuth -ErrorAction SilentlyContinue
         Remove-Item -Path env:ZabbixUri -ErrorAction SilentlyContinue
         Write-Verbose -Message "$JsonResponse"

--- a/src/Public/Disconnect-ZabbixServer.ps1
+++ b/src/Public/Disconnect-ZabbixServer.ps1
@@ -22,7 +22,7 @@ function Disconnect-ZabbixServer {
     )
 
     if (!($env:ZabbixUri)) {
-        Write-Warning -Message '$($MyInvocation.MyCommand.Name): No action sessions found.'
+        Write-Warning -Message "$($MyInvocation.MyCommand.Name): No active sessions found."
         break
     }
 

--- a/src/Public/Get-ZabbixHost.ps1
+++ b/src/Public/Get-ZabbixHost.ps1
@@ -56,7 +56,9 @@ function Get-ZabbixHost {
         [string] $Name,
 
         [Parameter()]
-        [switch] $Short
+        [switch] $Short,
+
+        $Certificate = $Global:Certificate
     )
 
     Begin {
@@ -106,7 +108,7 @@ function Get-ZabbixHost {
         Write-Verbose -Message "$($MyInvocation.MyCommand.Name): Sending JSON request object`n$($JsonRequest -Replace $env:ZabbixAuth, 'XXXXXX')"
 
         try {
-            $JsonResponse = Invoke-RestMethod -Uri $env:ZabbixUri -Method Put -Body $JsonRequest -ContentType 'application/json' -ErrorAction Stop
+            $JsonResponse = Invoke-RestMethod -Uri $env:ZabbixUri -Method Put -Body $JsonRequest -ContentType 'application/json' -Certificate $Certificate -ErrorAction Stop
             Write-Verbose -Message "$JsonResponse"
         }
         catch {

--- a/src/Public/Get-ZabbixHost.ps1
+++ b/src/Public/Get-ZabbixHost.ps1
@@ -62,7 +62,7 @@ function Get-ZabbixHost {
     )
 
     Begin {
-        if (!($env:ZabbixUri)) {
+        if (!($env:ZabbixAuth)) {
             Write-Warning -Message "$($MyInvocation.MyCommand.Name): No session information found. Use 'Connect-ZabbixServer' to login and create your Api session."
             break;
         }

--- a/src/Public/Get-ZabbixHostGroup.ps1
+++ b/src/Public/Get-ZabbixHostGroup.ps1
@@ -40,7 +40,7 @@ function Get-ZabbixHostGroup {
     )
 
     Begin {
-        if (!($env:ZabbixUri)) {
+        if (!($env:ZabbixAuth)) {
             Write-Warning -Message "$($MyInvocation.MyCommand.Name): No session information found. Use 'Connect-ZabbixServer' to login and create your Api session."
             break;
         }

--- a/src/Public/Get-ZabbixHostGroup.ps1
+++ b/src/Public/Get-ZabbixHostGroup.ps1
@@ -34,7 +34,9 @@ function Get-ZabbixHostGroup {
         [string] $Name,
 
         [Parameter()]
-        [switch] $Short
+        [switch] $Short,
+
+        $Certificate = $Global:Certificate
     )
 
     Begin {
@@ -75,7 +77,7 @@ function Get-ZabbixHostGroup {
         Write-Verbose -Message "$($MyInvocation.MyCommand.Name): Sending JSON request object`n$($JsonRequest -Replace $env:ZabbixAuth, 'XXXXXX')"
 
         try {
-            $JsonResponse = Invoke-RestMethod -Uri $env:ZabbixUri -Method Put -Body $JsonRequest -ContentType 'application/json' -ErrorAction Stop
+            $JsonResponse = Invoke-RestMethod -Uri $env:ZabbixUri -Method Put -Body $JsonRequest -ContentType 'application/json' -Certificate $Certificate -ErrorAction Stop
             Write-Verbose -Message "$JsonResponse"
         }
         catch {

--- a/src/Public/Get-ZabbixItem.ps1
+++ b/src/Public/Get-ZabbixItem.ps1
@@ -62,7 +62,7 @@ function Get-ZabbixItem {
     )
 
     Begin {
-        if (!($env:ZabbixUri)) {
+        if (!($env:ZabbixAuth)) {
             Write-Warning -Message "$($MyInvocation.MyCommand.Name): No session information found. Use 'Connect-ZabbixServer' to login and create your Api session."
             break;
         }

--- a/src/Public/Get-ZabbixItem.ps1
+++ b/src/Public/Get-ZabbixItem.ps1
@@ -56,7 +56,9 @@ function Get-ZabbixItem {
         [string] $Key,
 
         [Parameter()]
-        [switch] $Short
+        [switch] $Short,
+
+        $Certificate = $Global:Certificate
     )
 
     Begin {
@@ -105,7 +107,7 @@ function Get-ZabbixItem {
         Write-Verbose -Message "$($MyInvocation.MyCommand.Name): Sending JSON request object`n`t$($JsonRequest -Replace $env:ZabbixAuth, 'XXXXXX')"
 
         try {
-            $JsonResponse = Invoke-RestMethod -Uri $env:ZabbixUri -Method Put -Body $JsonRequest -ContentType 'application/json' -ErrorAction Stop
+            $JsonResponse = Invoke-RestMethod -Uri $env:ZabbixUri -Method Put -Body $JsonRequest -ContentType 'application/json' -Certificate $Certificate -ErrorAction Stop
         }
         catch {
             Write-Error "StatusCode: $($_.Exception.Response.StatusCode.value__)"

--- a/src/Public/Get-ZabbixItemHistory.ps1
+++ b/src/Public/Get-ZabbixItemHistory.ps1
@@ -46,7 +46,9 @@ function Get-ZabbixItemHistory {
         [int] $ValueType,
 
         [Parameter()]
-        [int] $Last = 1
+        [int] $Last = 1,
+
+        $Certificate = $Global:Certificate
     )
 
     Begin {
@@ -79,7 +81,7 @@ function Get-ZabbixItemHistory {
         Write-Verbose -Message "$($MyInvocation.MyCommand.Name): Sending JSON request object`n`t$($JsonRequest -Replace $env:ZabbixAuth, 'XXXXXX')"
 
         try {
-            $JsonResponse = Invoke-RestMethod -Uri $env:ZabbixUri -Method Put -Body $JsonRequest -ContentType 'application/json' -ErrorAction Stop
+            $JsonResponse = Invoke-RestMethod -Uri $env:ZabbixUri -Method Put -Body $JsonRequest -ContentType 'application/json' -Certificate $Certificate -ErrorAction Stop
         }
         catch {
             Write-Error "StatusCode: $($_.Exception.Response.StatusCode.value__)"

--- a/src/Public/Get-ZabbixItemHistory.ps1
+++ b/src/Public/Get-ZabbixItemHistory.ps1
@@ -52,7 +52,7 @@ function Get-ZabbixItemHistory {
     )
 
     Begin {
-        if (!($env:ZabbixUri)) {
+        if (!($env:ZabbixAuth)) {
             Write-Warning -Message "$($MyInvocation.MyCommand.Name): No session information found. Use 'Connect-ZabbixServer' to login and create your Api session."
             break;
         }

--- a/src/Public/Get-ZabbixTemplate.ps1
+++ b/src/Public/Get-ZabbixTemplate.ps1
@@ -54,7 +54,7 @@ function Get-ZabbixTemplate {
     )
 
     Begin {
-        if (!($env:ZabbixUri)) {
+        if (!($env:ZabbixAuth)) {
             Write-Warning -Message "$($MyInvocation.MyCommand.Name): No session information found. Use 'Connect-ZabbixServer' to login and create your Api session."
             break;
         }

--- a/src/Public/Get-ZabbixTemplate.ps1
+++ b/src/Public/Get-ZabbixTemplate.ps1
@@ -48,7 +48,9 @@ function Get-ZabbixTemplate {
         [string] $Name,
 
         [Parameter()]
-        [switch] $Short
+        [switch] $Short,
+
+        $Certificate = $Global:Certificate
     )
 
     Begin {
@@ -94,7 +96,7 @@ function Get-ZabbixTemplate {
         Write-Verbose -Message "$($MyInvocation.MyCommand.Name): Sending JSON request object`n`t$($JsonRequest -Replace $env:ZabbixAuth, 'XXXXXX')"
 
         try {
-            $JsonResponse = Invoke-RestMethod -Uri $env:ZabbixUri -Method Put -Body $JsonRequest -ContentType 'application/json' -ErrorAction Stop
+            $JsonResponse = Invoke-RestMethod -Uri $env:ZabbixUri -Method Put -Body $JsonRequest -ContentType 'application/json' -Certificate $Certificate -ErrorAction Stop
             Write-Verbose -Message "$JsonResponse"
         }
         catch {


### PR DESCRIPTION
- Added option for access by certificate.
- Disconnect check.
- Fixed incorrect removal of env variables.
- TLS 1.1 / 1.2 allow (without this could not access my instance of zabbix)

For certificate use, better way in your main script (to not specify cert var in every get-zabbix function):
$Global:Certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2('C:\client.p12')

After all operations:
Remove-Variable -Scope Global -Name Certificate -ErrorAction SilentlyContinue